### PR TITLE
feat: add reviewpad common.yml

### DIFF
--- a/reviewpad/common.yml
+++ b/reviewpad/common.yml
@@ -1,0 +1,99 @@
+# For more details see https://docs.reviewpad.com/guides/syntax#label.
+labels:
+  small:
+    description: Pull request is small
+    color: "#76dbbe"
+  medium:
+    description: Pull request is medium
+    color: "#2986cc"
+  large:
+    description: Pull request is large
+    color: "#c90076"
+  dependencies:
+    description: Something about our dependencies
+    color: "#ff8722"
+  test:
+    description: Marks issues or pull requests regarding tests
+    color: "#FCEA0A"
+  build:
+    description: Marks issues or pull requests regarding changes to the build tool
+    color: "#FCEA0F"
+  breaking-change:
+    description: Marks a pull request as introducing breaking changes
+    color: "#b3c9c9"
+  no-releasenotes:
+    description: To not include a pull request in the changelog
+    color: "#333635"
+  needs-review:
+    description: Marks a pull request as waiting for review
+    color: "#aa2297"
+
+# For more details see https://docs.reviewpad.com/guides/syntax#workflow.
+workflows:
+  # This workflow praises contributors on their pull request contributions.
+  # This helps contributors feel appreciated.
+  - name: praise-contributors
+    description: Praise contributors
+    always-run: true
+    if:
+      # Praise contributors on their first pull request.
+      - rule: $pullRequestCountBy($author()) == 1
+        extra-actions:
+          - $commentOnce($sprintf("Thank you @%s for your first contribution!", [$author()]))
+      # Praise contributors on their 10th pull request.
+      - rule: $pullRequestCountBy($author()) == 10
+        extra-actions:
+          - $commentOnce($sprintf("Way to go @%s... This is your 10th pull request! 🎉", [$author()]))
+
+  # This workflow validates that pull requests follow the conventional commits specification.
+  # This helps us automatically generate changelogs.
+  # For more details, see https://www.conventionalcommits.org/en/v1.0.0/.
+  # The unerlying parser is https://github.com/leodido/go-conventionalcommits.
+  - name: check-conventional-commits
+    description: Validate that pull requests follow the conventional commits
+    always-run: true
+    if:
+      - rule: $isDraft() == false
+    then:
+      # Check commits messages against the conventional commits specification
+      - $commitLint()
+      # Check pull request title against the conventional commits specification.
+      - $titleLint()
+
+  # This workflow validates best practices for pull request management.
+  # This helps developers follow best practices.
+  - name: best-practices
+    description: Validate best practices for pull request management
+    always-run: true
+    if:
+      # Warn pull requests that do not have an associated GitHub issue.
+      - rule: $hasLinkedIssues() == false
+        extra-actions:
+          - $warn("Please link an issue to the pull request")
+      # Warn pull requests if their description is empty.
+      - rule: $description() == ""
+        extra-actions:
+          - $warn("Please provide a description for the pull request")
+      # Warn pull request do not have a clean linear history.
+      - rule: $hasLinearHistory() == false
+        extra-actions:
+          - $warn("Please rebase your pull request on the latest changes")
+
+  # This workflow labels pull requests depending on the total number of lines changed.
+  # This helps pick pull requests based on their size and to incentivize small pull requests.
+  - name: size-labeling
+    description: Label pull request based on the number of lines changed
+    always-run: true
+    if:
+      - rule: $size($group("ignore-patterns")) < 100
+        extra-actions:
+          - $removeLabels(["medium", "large"])
+          - $addLabel("small")
+      - rule: $size($group("ignore-patterns")) >= 100 && $size($group("ignore-patterns")) < 300
+        extra-actions:
+          - $removeLabels(["small", "large"])
+          - $addLabel("medium")
+      - rule: $size($group("ignore-patterns")) >= 300
+        extra-actions:
+          - $removeLabels(["small", "medium"])
+          - $addLabel("large")


### PR DESCRIPTION
This pull request introduces a common Reviewpad configuration that can be used in all the repositories of the listendev organization through the [`extends` feature](https://docs.reviewpad.com/guides/extends).